### PR TITLE
Correct minor typos and PEP8 violations

### DIFF
--- a/bin/review-rot
+++ b/bin/review-rot
@@ -72,7 +72,6 @@ def main(state_, value, duration):
         print(result.format(style=args.format))
 
 
-
 def format_user_repo_name(data):
     """
     Takes input from configuration file for a specified git service.
@@ -92,10 +91,10 @@ def format_user_repo_name(data):
         repo_name = None
     return {'user_name': user_name, 'repo_name': repo_name}
 
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
-        description='Lists pull/merge requests for github, gitlab,'
-                    'pagure and gerrit')
+        description='Lists pull/merge requests for github, gitlab and pagure')
     parser.add_argument('-s', '--state',
                         default=None,
                         choices=['older', 'newer'],
@@ -120,7 +119,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     options = (args.state, args.value, args.duration)
     if any(options) and not all(options):
-        parser.error('Either none or all arguments are required')
+        parser.error('Either no or all arguments are required')
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ setup(name='review-rot',
       author='Nirzari Iyer',
       author_email='niyer@redhat.com',
       description=('CLI tool to list review(pull) requests from '
-                   'github,gitlab,pagure and gerrit'),
+                   'github, gitlab and pagure'),
       long_description=long_description,
-      license='GNU GENERAL PUBLIC LICENSE Version 3',
+      license='GPLv3',
       url='https://github.com/nirzari/review-rot',
       packages=find_packages(),
       install_requires=[


### PR DESCRIPTION
1. Removed references to gerrit (not yet supported)
2. Corrected a few line length/blank line PEP8 violations
   (but didn't correct some line length problems in the tests)
3. Renamed "GNU GENERAL PUBLIC LICENSE Version 3" to "GPLv3"