### PR TITLE
Add SSL configuration arguments and options

### DIFF
--- a/bin/review-rot
+++ b/bin/review-rot
@@ -5,11 +5,11 @@ import os
 import logging
 import argparse
 import yaml
-from os.path import expanduser
+from os.path import expanduser, expandvars
 from reviewrot import get_git_service
 
 
-def main(state_, value, duration):
+def main(state_, value, duration, ssl_verify=None):
     """
     Reads input configuration file.
     Calls appropriate git service with suitable inputs.
@@ -39,6 +39,16 @@ def main(state_, value, duration):
 
         # get git service
         git_service = get_git_service(item['type'])
+
+        # use configuration SSL settings by default, override with argument
+        if ssl_verify is None and 'ssl_verify' in item:
+            ssl_verify = item['ssl_verify']
+            # expand ~, environment variables, etc if it's a path
+            if not isinstance(ssl_verify, bool):
+                ssl_verify = expanduser(expandvars(ssl_verify))
+            log.debug('Using ssl_verify value "%s" from configuration',
+                      ssl_verify)
+
         """
         check if username and/or repository information is given for
         specified git service
@@ -64,6 +74,7 @@ def main(state_, value, duration):
                         duration=duration,
                         token=item.get('token'),
                         host=item.get('host'),
+                        ssl_verify=ssl_verify,
                     )
                 )
 
@@ -117,6 +128,19 @@ if __name__ == '__main__':
                         help='Choose from one of a few different styles.')
     parser.add_argument('--debug', action='store_true',
                         help='Display debug logs on console')
+
+    ssl_group = parser.add_argument_group('SSL')
+    ssl_group.add_argument('-k', '--insecure',
+                           default=False,
+                           action='store_true',
+                           help='Disable SSL certificate verification '
+                                '(not recommended).')
+    ssl_group.add_argument('--cacert',
+                           default=None,
+                           type=open,
+                           help='Path to CA certificate to use for SSL '
+                                'certificate verification.')
+
     args = parser.parse_args()
     options = (args.state, args.value, args.duration)
     if any(options) and not all(options):
@@ -127,4 +151,5 @@ if __name__ == '__main__':
     else:
         logging.basicConfig(level=logging.INFO)
 
-    main(state_=args.state, value=args.value, duration=args.duration)
+    main(state_=args.state, value=args.value, duration=args.duration,
+         ssl_verify=False if args.insecure else args.cacert)

--- a/reviewrot/githubstack.py
+++ b/reviewrot/githubstack.py
@@ -12,7 +12,8 @@ class GithubService(BaseService):
     https://developer.github.com/v3/
     """
     def request_reviews(self, user_name, repo_name=None, state_=None,
-                        value=None, duration=None, token=None, host=None):
+                        value=None, duration=None, token=None, host=None,
+                        **kwargs):
         """
         Creates a github object.
         Requests pull requests for specified username and repo name.

--- a/reviewrot/gitlabstack.py
+++ b/reviewrot/gitlabstack.py
@@ -14,7 +14,8 @@ class GitlabService(BaseService):
      https://docs.gitlab.com/ee/api/
     """
     def request_reviews(self, user_name, repo_name=None, state_=None,
-                        value=None, duration=None, token=None, host=None):
+                        value=None, duration=None, token=None, host=None,
+                        ssl_verify=True, **kwargs):
         """
         Creates a gitlab object.
         Requests merge requests for specified username and repo name.
@@ -34,13 +35,14 @@ class GitlabService(BaseService):
                             newer than
             token (str): Gitlab token for authentication
             host (str): Gitlab host name for authentication
-
+            ssl_verify (bool/str): Whether or not to verify SSL certificates,
+                                   or a path to a CA file to use.
         Returns:
             response (list): Returns list of list of pull requests for
                              specified user(group) name and projectname or all
                              projectname for given groupname
         """
-        gl = gitlab.Gitlab(host, token)
+        gl = gitlab.Gitlab(host, token, ssl_verify=ssl_verify)
         gl.auth()
         log.debug('Gitlab instance created: %s', gl)
         response = []

--- a/reviewrot/pagurestack.py
+++ b/reviewrot/pagurestack.py
@@ -14,7 +14,8 @@ class PagureService(BaseService):
         self.header = None
 
     def request_reviews(self, user_name, repo_name=None, state_=None,
-                        value=None, duration=None, host=None, token=None):
+                        value=None, duration=None, host=None, token=None,
+                        ssl_verify=True, **kwargs):
         """
         Fetches merge requests by making API calls for specified
         username(namespace) and repo(project) name.
@@ -35,6 +36,8 @@ class PagureService(BaseService):
                          (Commented for unauthenticated request)
             host (str): Pagure host name (This value is not yet supported.
                         The default behavior is to use public pagure instance)
+            ssl_verify (bool/str): Whether or not to verify SSL certificates,
+                                   or a path to a CA file to use.
         Returns:
             res_ (list): Returns list of pull requests for specified
                          namespace and/or repo name
@@ -57,7 +60,7 @@ class PagureService(BaseService):
             log.debug('Looking for pull requests for %s -> %s',
                       'pagure.io',  repo_name)
         log.debug('Calling API with request_url: %s', request_url)
-        response = self._call_api(url=request_url)
+        response = self._call_api(url=request_url, ssl_verify=ssl_verify)
         res_ = []
         for res in response['requests']:
             # if namespace exists in response
@@ -96,7 +99,7 @@ class PagureService(BaseService):
             res_.append(res)
         return res_
 
-    def _call_api(self, url, method='GET'):
+    def _call_api(self, url, method='GET', ssl_verify=True):
         """
         Method used to call the API.
         It returns the raw JSON returned by the API or raises an exception
@@ -113,6 +116,7 @@ class PagureService(BaseService):
             method=method,
             url=url,
             headers=self.header,
+            verify=ssl_verify,
         )
         output = None
         try:


### PR DESCRIPTION
Adds `-k`/`--insecure` and `--cacert` arguments and `ssl_verify` option to control global SSL verification control. Setting `-k`/`--insecure` is equivalent to setting `ssl_verify: false`; setting `--cacert path/to/cert` is equivalent to setting `ssl_verify: path/to/cert`. The values correspond to the `requests` module's session `verify` property:

http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
http://docs.python-requests.org/en/master/api/#requests.Session.verify

Caveats:
- PyGithub currently doesn't support SSL configuration.
- No tests.