### PR TITLE
Make review-rot output valid JSON.

### DIFF
--- a/bin/review-rot
+++ b/bin/review-rot
@@ -11,6 +11,10 @@ from reviewrot import get_git_service, GerritService
 
 import yaml
 
+# Characters to include at the beginning and end of reports
+report_prefixes = {'oneline': '', 'indented': '', 'json': '['}
+report_suffixes = {'oneline': '', 'indented': '', 'json': ']'}
+
 
 def main(state_, value, duration, ssl_verify=None):
     """
@@ -86,8 +90,12 @@ def main(state_, value, duration, ssl_verify=None):
         key=operator.attrgetter('time'),
         reverse=args.reverse,
     )
-    for result in sorted_results:
-        print(result.format(style=args.format))
+
+    N = len(results)
+    print(report_prefixes[args.format])
+    for i, result in enumerate(sorted_results):
+        print(result.format(style=args.format, i=i, N=N))
+    print(report_suffixes[args.format])
 
 
 def format_user_repo_name(data, git_service):

--- a/reviewrot/basereview.py
+++ b/reviewrot/basereview.py
@@ -192,15 +192,21 @@ class BaseReview(object):
     def __str__(self):
         return self.format('oneline')
 
-    def format(self, style):
+    def format(self, style, i, N):
+        """ Format the result in a given style.
+
+        style - the name of the style.
+        i - an integer, indicating the position in a list.
+        N - the total size of the list.
+        """
         lookup = {
             'oneline': self._format_oneline,
             'indented': self._format_indented,
             'json': self._format_json,
         }
-        return lookup[style]()
+        return lookup[style](i, N)
 
-    def _format_oneline(self):
+    def _format_oneline(self, i, N):
         string = "@%s filed '%s' %s since %s" % (
             self.user, self.title, self.url, self.since)
 
@@ -211,7 +217,7 @@ class BaseReview(object):
 
         return string
 
-    def _format_indented(self):
+    def _format_indented(self, i, N):
         string = "@%s filed '%s'\n\t%s\n\tsince %s" % (
             self.user, self.title, self.url, self.since)
 
@@ -222,9 +228,11 @@ class BaseReview(object):
 
         return string
 
-    def _format_json(self):
+    def _format_json(self, i, N):
         import json
-        return json.dumps(self.__json__(), indent=2)
+        # Include a comma after every entry, except the last.
+        suffix = ',' if i < N - 1 else ''
+        return json.dumps(self.__json__(), indent=2) + suffix
 
     def __json__(self):
         return {


### PR DESCRIPTION
Now review-rot can print real, parse-able JSON instead of fake,
un-parse-able JSON.

We can use this to have review-rot's output be fed to other tools.