### PR TITLE
Fix pagure avatars.

### DIFF
--- a/reviewrot/pagurestack.py
+++ b/reviewrot/pagurestack.py
@@ -115,8 +115,8 @@ class PagureService(BaseService):
         Pagure avatars have a predictable URL structure.
         """
         query = urlencode({'s': 64, 'd': 'retro'})
-        openid = 'http://%s.id.fedoraproject.org' % username
-        idx = hashlib.sha256(openid).hexdigest()
+        openid = u'http://%s.id.fedoraproject.org/' % username
+        idx = hashlib.sha256(openid.encode('utf-8')).hexdigest()
         return "https://seccdn.libravatar.org/avatar/%s?%s" % (idx, query)
 
 

--- a/reviewrot/pagurestack.py
+++ b/reviewrot/pagurestack.py
@@ -2,7 +2,11 @@ import datetime
 import hashlib
 import logging
 import os
-import urllib
+
+try:
+    from urllib.parse import urlencode  # python3
+except ImportError:
+    from urllib import urlencode  # python2
 
 import requests
 
@@ -110,7 +114,7 @@ class PagureService(BaseService):
 
         Pagure avatars have a predictable URL structure.
         """
-        query = urllib.urlencode({'s': 64, 'd': 'retro'})
+        query = urlencode({'s': 64, 'd': 'retro'})
         openid = 'http://%s.id.fedoraproject.org' % username
         idx = hashlib.sha256(openid).hexdigest()
         return "https://seccdn.libravatar.org/avatar/%s?%s" % (idx, query)

--- a/test/test.py
+++ b/test/test.py
@@ -138,6 +138,13 @@ class PagureTest(TestCase):
         with open(filename, 'r') as f:
             self.config = yaml.load(f)
 
+    def test_pagure_avatar(self):
+        expected = ('https://seccdn.libravatar.org/avatar/'
+                    '9c9f7784935381befc302fe3c814f9136e7a3'
+                    '3953d0318761669b8643f4df55c')
+        actual = PagureService._avatar('ralph')
+        self.assertEqual(actual.split('?')[0], expected)
+
     def test_pagure_object_create(self):
         self.assertTrue(isinstance((get_git_service('pagure')), PagureService))
 


### PR DESCRIPTION
The main issue is the missing '/' character at the end of the openid
string.  It meant that every avatar was wrong.

I added a test to ensure that the right URL is constructed.