### PR TITLE
GitLab MR author is now a dict, not an object

### DIFF
--- a/reviewrot/gitlabstack.py
+++ b/reviewrot/gitlabstack.py
@@ -151,7 +151,7 @@ class GitlabService(BaseService):
                 log.debug("merge request '%s' is not %s than specified"
                           " time interval", mr.title, state_)
                 continue
-            res = GitlabReview(user=mr.author.username,
+            res = GitlabReview(user=mr.author['username'],
                                title=mr.title,
                                url=mr.web_url,
                                time=mr_date,


### PR DESCRIPTION
Not sure why this changed, but the value that python-gitlab provides for the merge request author is now a dict and must be indexed by key, instead of having its properties stored as attributes.