### PR TITLE
Specify versions of python modules in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,11 @@ setup(name='review-rot',
       url='https://github.com/nirzari/review-rot',
       packages=find_packages(),
       install_requires=[
+          'requests>=2.14.0',
           'PyGithub',
           'PyYAML',
           'dateutils',
-          'python-gitlab'
+          'python-gitlab==1.5.1',
       ],
       tests_require=[
           'nose',


### PR DESCRIPTION
I created the rhel-7.5 container for the run the review-rot and I found out that there is the need to add **requests** version which is lower on rhel-7.5. Another problem came up with library **python-gitlab** when they released the new version 1.6 where they removed "v3.object" and the review-rot start failing.

Thank you for help @ddelabru 