### PR TITLE
Show WIP pull requests in a different section.

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -21,6 +21,11 @@
 			<div id="reviews">
 				<!-- site.js populates this div with the reviews. -->
 			</div>
+			<hr/>
+			<h2 id="wip-header" class="hidden">Work In Progress Reviews</h2>
+			<div id="wip-reviews">
+				<!-- site.js populates this div with the WIP reviews. -->
+			</div>
 		</div>
 
 		<footer class="footer">

--- a/web/js/default-data.json
+++ b/web/js/default-data.json
@@ -5,8 +5,18 @@
   "title": "modify web/js/site.js to point to the output of 'reviewrot -f json'",
   "url": "https://github.com/nirzari/review-rot/pull/44",
   "image": "https://ih1.redbubble.net/image.106544476.3270/flat,800x800,075,f.jpg",
-  "time": 1496403471.0, 
+  "time": 1496403471.0,
   "type": "...",
   "comments": 9999
+},
+{
+  "relative_time": "sometime",
+  "user": "YOU",
+  "title": "this is a WIP PR",
+  "url": "https://github.com/nirzari/review-rot/pull/44",
+  "image": "https://ih1.redbubble.net/image.106544476.3270/flat,800x800,075,f.jpg",
+  "time": 1496403471.0,
+  "type": "...",
+  "comments": 0
 }
 ]

--- a/web/js/site.js
+++ b/web/js/site.js
@@ -28,7 +28,12 @@ $(document).ready(function() {
 				generated: moment(modified).fromNow()
 			}));
 			$.each(data, function(key, value) {
-				$('#reviews').append(entry_template(value));
+				if (value.title.indexOf("WIP") == -1) {
+					$('#reviews').append(entry_template(value));
+				} else {
+					$('#wip-header').removeClass('hidden');
+					$('#wip-reviews').append(entry_template(value));
+				}
 			});
 			$('.page-header').append(stats_template(average_age(data)));
 		}


### PR DESCRIPTION
This is a change to the generated static webpage.  WIP reviews are now shown in
a lower section all by themselves (so that their long-lived selves don't
clutter the queue of reviews that can receive more immediate attention).