### PR TITLE
Raise python-gitlab version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='review-rot',
           'PyGithub',
           'PyYAML',
           'dateutils',
-          'python-gitlab==1.5.1',
+          'python-gitlab>=1.6.0',
       ],
       tests_require=[
           'nose',


### PR DESCRIPTION
Testing a review-rot container today, similar to the one @pbortlov was trying to build a couple weeks ago, I was unable to recreate the import error tracebacks we were getting from python-gitlab at the time with python-gitlab version dependency set to >=1.6.0.

I'm not sure why it works now, but as long as it does, we may prefer to allow more recent versions of python-gitlab.