### PR TITLE
don't raise an error when irc and show_last_comment are set

### DIFF
--- a/reviewrot/__init__.py
+++ b/reviewrot/__init__.py
@@ -149,11 +149,6 @@ def get_arguments(cli_arguments, config, choices):
         )
 
     irc = parsed_arguments.get('irc')
-    if irc and show_last_comment is not None:
-        raise ValueError(
-            'IRC output doesn\'t support last comment functionality'
-        )
-
     email = parsed_arguments.get('email')
     if email and format:
         raise ValueError(


### PR DESCRIPTION
The same config file can be used for email and irc notifications simultaneously.
It should not be an error for the user to choose show_last_comment for their email
notifications while also using irc. The irc integration simply ignores the presence
of that option.